### PR TITLE
fix(pipeline): reviewed image version and tags striped during publishing

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -23,7 +23,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/
 
   publish_production:
-    if: (github.event.pull_request.merged == true && github.base_ref == 'master')
+    if: (github.event.pull_request.merged == true && github.base_ref == 'master' || startsWith(github.ref, 'refs/tags/v') )
 
     strategy:
       matrix:
@@ -57,12 +57,10 @@ jobs:
         # e.g. refs/heads/master or refs/tags/v1.2.3
         # for push: branch or pushed tag
         # for pull_request: pr merge branch
-        #VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        VERSION=${{ github.ref_name }}
+        # VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-        echo "ref_name "
-        echo ${{ github.ref_name }}
-        echo $(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        # simplified version
+        VERSION=${{ github.ref_name }}
 
         if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
             # Strip "v" prefix from tag name
@@ -73,8 +71,8 @@ jobs:
             [[ "$VERSION" == "master" ]] && VERSION=latest
         fi
 
-        echo IMAGE_ID=$IMAGE_ID
-        echo VERSION=$VERSION
+        echo GENERATED IMAGE_ID: $IMAGE_ID
+        echo GENERATED VERSION: $VERSION
 
         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-        # disabled publishing for now docker push $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
A separated workflow to build and publish images was made, so this PR applies some improvements on:

- Image version generated by pushing TAGS
- Image version generated by merging a branch, for now on, only merges to Master will have images released as "latest". In the previous version, images were published before being really merged into the production branch.  